### PR TITLE
Objective C Plugin

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN mkdir -p $HOME/plugins
 
 ENV GITLAB_PLUGIN_VERSION 3.0.2
 RUN set -x && curl -sLo $HOME/plugins/sonar-gitlab-plugin-${GITLAB_PLUGIN_VERSION}.jar \
-	http://nexus.talanlabs.com/content/groups/public_release/com/synaptix/sonar-gitlab-plugin/${GITLAB_PLUGIN_VERSION}/sonar-gitlab-plugin-${GITLAB_PLUGIN_VERSION}.jar
+	https://github.com/gabrie-allaigre/sonar-gitlab-plugin/releases/download/${GITLAB_PLUGIN_VERSION}/sonar-gitlab-plugin-${GITLAB_PLUGIN_VERSION}.jar
 
 ENV SLACK_PLUGIN_VERSION 2.1.2
 RUN set -x && curl -sLo $HOME/plugins/cks-slack-notifier-${SLACK_PLUGIN_VERSION}.jar \
@@ -24,9 +24,9 @@ ENV ANDROID_LINT_PLUGIN_VERSION 1.1
 RUN set -x && curl -sLo $HOME/plugins/sonar-android-plugin-${ANDROID_LINT_PLUGIN_VERSION}.jar \
 	https://github.com/SonarQubeCommunity/sonar-android/releases/download/${ANDROID_LINT_PLUGIN_VERSION}/sonar-android-plugin-${ANDROID_LINT_PLUGIN_VERSION}.jar
 
-ENV JAVA_PLUGIN_VERSION 4.6.0.8784
+ENV JAVA_PLUGIN_VERSION 5.9.2.16552
 RUN set -x && curl -sLo $HOME/plugins/sonar-java-plugin-${JAVA_PLUGIN_VERSION}.jar \
-	https://sonarsource.bintray.com/Distribution/sonar-java-plugin/sonar-java-plugin-${JAVA_PLUGIN_VERSION}.jar
+	https://binaries.sonarsource.com/Distribution/sonar-java-plugin/sonar-java-plugin-${JAVA_PLUGIN_VERSION}.jar
 
 ENV KOTLIN_PLUGIN_VERSION 0.5.2
 RUN set -x && curl -sLo $HOME/plugins/sonar-kotlin-plugin-${KOTLIN_PLUGIN_VERSION}.jar \

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,10 +16,6 @@ ENV SLACK_PLUGIN_VERSION 2.1.2
 RUN set -x && curl -sLo $HOME/plugins/cks-slack-notifier-${SLACK_PLUGIN_VERSION}.jar \
 	https://github.com/kogitant/sonar-slack-notifier-plugin/releases/download/${SLACK_PLUGIN_VERSION}/cks-slack-notifier-${SLACK_PLUGIN_VERSION}.jar
 
-ENV OBJECTIVE_C_PLUGIN_VERSION 0.6.2
-RUN set -x && curl -sLo $HOME/plugins/backelite-sonar-objective-c-plugin-${OBJECTIVE_C_PLUGIN_VERSION}.jar \
-	https://github.com/Backelite/sonar-objective-c/releases/download/${OBJECTIVE_C_PLUGIN_VERSION}/backelite-sonar-objective-c-plugin-${OBJECTIVE_C_PLUGIN_VERSION}.jar
-
 ENV SWIFT_PLUGIN_VERSION 0.4.2
 RUN set -x && curl -sLo $HOME/plugins/backelite-sonar-swift-plugin-${SWIFT_PLUGIN_VERSION}.jar \
 	https://github.com/Backelite/sonar-swift/releases/download/${SWIFT_PLUGIN_VERSION}/backelite-sonar-swift-plugin-${SWIFT_PLUGIN_VERSION}.jar


### PR DESCRIPTION
-Remove deprecated objective c plugin. Now the analysis of this language is done by swift backelite plugin. 

-Update versions of `gitlab` and `java` plugins